### PR TITLE
enable some smoke tests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,6 +19,6 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Run fmt check
         run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,11 +966,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_mock"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusoto_s3"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1084,7 @@ dependencies = [
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_mock 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1791,6 +1806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ring 0.16.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 "checksum rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
 "checksum rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba3e7cdf483d7198d9bca7414746d3ba656239e89e467b715d0571912f0b492f"
+"checksum rusoto_mock 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "20617d47af0e8ce5c46f4b8243b13f6e72b67c1c2853a2a1bb9af8729f79f8eb"
 "checksum rusoto_s3 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b6bc3221ae5a2c036d5757eee68a2ffb6b7f87b8a83adbf4271c8133fdee01c"
 "checksum rusoto_signature 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
 "checksum rust-argon2 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "416f5109bdd413cec4f04c029297838e7604c993f8d1483b1d438f23bdc3eb35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ features = [ "rustls" ]
 tempfile = "3"
 remove_dir_all = "0.5"
 
+[dev-dependencies.rusoto_mock]
+version = "0.43"
+default-features = false
+features = [ "rustls" ]
+
 [build-dependencies]
 version_check = "0.9"
 structopt = "0.3"

--- a/src/function.rs
+++ b/src/function.rs
@@ -60,7 +60,7 @@ dyn_clone::clone_trait_object!(RunCommand);
 
 impl FastPrint {
     #[inline]
-    pub fn print_object<I: std::io::Write>(
+    fn print_object<I: Write>(
         &self,
         io: &mut I,
         bucket: &str,
@@ -94,7 +94,7 @@ impl RunCommand for FastPrint {
 
 impl AdvancedPrint {
     #[inline]
-    pub fn print_object<I: std::io::Write>(
+    fn print_object<I: Write>(
         &self,
         io: &mut I,
         bucket: &str,
@@ -138,7 +138,8 @@ impl RunCommand for AdvancedPrint {
 }
 
 impl Exec {
-    pub fn exec<I: std::io::Write>(&self, io: &mut I, key: &str) -> Result<ExecStatus, Error> {
+    #[inline]
+    fn exec<I: Write>(&self, io: &mut I, key: &str) -> Result<ExecStatus, Error> {
         let command_str = self.utility.replace("{}", key);
 
         let mut command_args = command_str.split(' ');
@@ -558,7 +559,6 @@ mod tests {
         };
 
         cmd.print_object(&mut buf, bucket, &object)?;
-
         let out = std::str::from_utf8(&buf)?;
 
         assert!(out.contains("9d48114aa7c18f9d68aa20086dbb7756"));
@@ -586,7 +586,6 @@ mod tests {
         };
 
         cmd.print_object(&mut buf, bucket, &object)?;
-
         let out = std::str::from_utf8(&buf)?;
 
         assert!(out.contains("s3://test/somepath/otherpath"));

--- a/src/function.rs
+++ b/src/function.rs
@@ -900,4 +900,32 @@ mod tests {
         assert!(res.is_ok());
         Ok(())
     }
+
+    #[tokio::test]
+    async fn smoke_s3_move() -> Result<(), Error> {
+        let mock = MockRequestDispatcher::with_status(200);
+        let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let object = Object {
+            e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+            key: Some("key".to_string()),
+            last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+            owner: None,
+            size: Some(4997288),
+            storage_class: Some("STANDARD".to_string()),
+        };
+
+        let cmd = S3Move {
+            destination: ("s3://test/1").parse()?,
+            flat: false,
+        };
+
+        let copy_path = "s3://test/1".parse()?;
+
+        let res = cmd
+            .execute(&client, "us-east-1", &copy_path, &[object])
+            .await;
+        assert!(res.is_ok());
+        Ok(())
+    }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -678,6 +678,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn smoke_exec() -> Result<(), Error> {
+        let object = Object {
+            e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+            key: Some("somepath/otherpath".to_string()),
+            last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+            owner: None,
+            size: Some(4_997_288),
+            storage_class: Some("STANDARD".to_string()),
+        };
+
+        let cmd = Exec {
+            utility: "echo {}".to_owned(),
+        };
+        let region = "us-east-1";
+        let client = S3Client::new(Region::UsEast1);
+        let path = S3path {
+            bucket: "test".to_owned(),
+            prefix: None,
+        };
+
+        cmd.execute(&client, region, &path, &[object]).await
+    }
+
+    #[tokio::test]
     async fn smoke_s3_delete() -> Result<(), Error> {
         let mock = MockRequestDispatcher::with_status(200).with_body(
             r#"

--- a/src/function.rs
+++ b/src/function.rs
@@ -570,6 +570,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn smoke_s3_set_public() -> Result<(), Error> {
+        let mock = MockRequestDispatcher::with_status(200);
+        let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let objects = &[
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample1.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample2.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+        ];
+
+        let set = SetPublic {};
+        let path = "s3://testbucket".parse()?;
+
+        let res = set.execute(&client, "us-east1", &path, objects).await;
+        assert!(res.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn smoke_s3_set_tags() -> Result<(), Error> {
+        let mock = MockRequestDispatcher::with_status(200);
+        let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let objects = &[
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample1.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample2.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+        ];
+
+        let tags = vec![
+            FindTag {
+                key: "testkey1".to_owned(),
+                value: "testvalue1".to_owned(),
+            },
+            FindTag {
+                key: "testkey2".to_owned(),
+                value: "testvalue2".to_owned(),
+            },
+        ];
+
+        let set_tags = SetTags { tags };
+        let path = "s3://testbucket".parse()?;
+
+        let res = set_tags.execute(&client, "us-east-1", &path, objects).await;
+        assert!(res.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn smoke_s3_list_tags() -> Result<(), Error> {
+        let mock = MockRequestDispatcher::with_status(200);
+        let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let objects = &[
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample1.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+            Object {
+                e_tag: Some("9d48114aa7c18f9d68aa20086dbb7756".to_string()),
+                key: Some("sample2.txt".to_string()),
+                last_modified: Some("2017-07-19T19:04:17.000Z".to_string()),
+                owner: None,
+                size: Some(4997288),
+                storage_class: Some("STANDARD".to_string()),
+            },
+        ];
+
+        let list = ListTags {};
+        let path = "s3://testbucket".parse()?;
+
+        let res = list.execute(&client, "us-east-1", &path, objects).await;
+        assert!(res.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn smoke_s3_copy() -> Result<(), Error> {
         let mock = MockRequestDispatcher::with_status(200);
         let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);


### PR DESCRIPTION
`rusoto_mock` supports `rustls`.

* removed smock tests are returned back and adapted to async traits.
* print output was moved to internal implementation to allow test output 