### PR TITLE
Revert "switch to jemalloc to mitigate musl slow alloc"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,12 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs_extra"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,27 +634,6 @@ name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1200,7 +1173,6 @@ dependencies = [
  "humansize",
  "indicatif",
  "itertools",
- "jemallocator",
  "regex",
  "remove_dir_all",
  "rusoto_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ itertools = "0.9"
 tokio = "0.2"
 async-trait = "0.1"
 dyn-clone = "1"
-[target.'cfg(all(not(target_env = "msvc"), not(target_os = "freebsd")))'.dependencies]
-jemallocator = "0.3"
 
 [dependencies.clap]
 version = "2"

--- a/src/bin/s3find.rs
+++ b/src/bin/s3find.rs
@@ -1,10 +1,3 @@
-#[cfg(all(not(target_env = "msvc"), not(target_os = "freebsd")))]
-use jemallocator::Jemalloc;
-
-#[cfg(all(not(target_env = "msvc"), not(target_os = "freebsd")))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
-
 use anyhow::Error;
 use structopt::StructOpt;
 


### PR DESCRIPTION
Currently jemalloc could not be compiled with static musl.