### PR TITLE
basic tests of execute and streams, remove bin from coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/bin/s3find.rs"


### PR DESCRIPTION
## Pull Request Overview

This PR introduces tests to validate the functionality of exec function and updates the codecov configuration.  
- Adds unit test  for exec function 
- Add unit test to verify FindStream
- Add unit test to verify FindStream could be converted into stream



