### PR TITLE
add macos-13 and ubuntu-24.04-arm as tested oses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13, ubuntu-24.04-arm]
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: toolchain
         uses: dtolnay/rust-toolchain@stable
-        if: matrix.os == 'macOS-latest'
       - name: build
         run: cargo build --verbose
       - name: test


### PR DESCRIPTION
This PR adds build and test on macos-13(x64) and ubuntu-24.04-arm